### PR TITLE
Feature/software icon export on pr11

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+Changes from recovered fw dir. Not sure if this is latest

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
-# Framework Laptop 16 LED Matrix Input Module Controlh
+# Framework Laptop 16 LED Matrix Input Module Control
 
-## The upstream repo is apparently no longer monitored, so this fork will probably never be merged.
-
-The following enhancements are provided:
-
-- Import export capability
-  - Matrix values are saved as a 39 by 9 byte array
-- Persist button
-  - Continually wakes the matrix when selected, so the display does not turn off
- 
 [View it in your browser.](https://ledmatrix.frame.work)
 
 This little web app can directly connect to the Framework Laptop 16 LED matrix
@@ -25,6 +16,15 @@ will automatically update on your physical device.
 Click and drag to draw, CTRL + click to erase.
 
 Brightness can also be adjusted using the slider.
+
+## Features
+
+- Import/export capability for matrix patterns
+  - Matrix values are saved as a 34 by 9 byte array
+- Persist button
+  - Continually wakes the matrix when selected, so the display does not turn off
+- Export for Software
+  - Export patterns in column-major format (9x34) with binary or grayscale values
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# Framework Laptop 16 LED Matrix Input Module Control
+# Framework Laptop 16 LED Matrix Input Module Controlh
 
+## The upstream repo is apparently no longer monitored, so this fork will probably never be merged.
+
+The following enhancements are provided:
+
+- Import export capability
+  - Matrix values are saved as a 39 by 9 byte array
+- Persist button
+  - Continually wakes the matrix when selected, so the display does not turn off
+ 
 [View it in your browser.](https://ledmatrix.frame.work)
 
 This little web app can directly connect to the Framework Laptop 16 LED matrix

--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ $(function() {
   updateTableLeft();
   updateTableRight();
   initOptions();
+  initSoftwareExportOptions();
   startWakeLoop()
 
   for (const pattern of PATTERNS) {
@@ -203,6 +204,49 @@ function initOptions() {
     command(portLeft, BRIGHTNESS_CMD, brightness);
     command(portRight, BRIGHTNESS_CMD, brightness);
   });
+}
+
+function initSoftwareExportOptions() {
+  $('#exportLeftSoftwareBtn').click(function() {
+    const grayscale = $('input[name="exportFormat"]:checked').val() !== 'binary';
+    exportMatrixSoftware(matrix_left, 'left', grayscale);
+  });
+
+  $('#exportRightSoftwareBtn').click(function() {
+    const grayscale = $('input[name="exportFormat"]:checked').val() !== 'binary';
+    exportMatrixSoftware(matrix_right, 'right', grayscale);
+  });
+}
+
+function exportMatrixSoftware(matrix, side, grayscale = true) {
+  const width = matrix[0].length;   // 9
+  const height = matrix.length;     // 34
+
+  // Fixed column-major: 9 columns x 34 rows
+  const vals = Array(width).fill(0).map(() => Array(height).fill(0));
+  for (let col = 0; col < width; col++) {
+    for (let row = 0; row < height; row++) {
+      const isLit = matrix[row][col] === 0;  // LED on
+      if (grayscale) {
+        vals[col][row] = isLit ? 255 : 0;
+      } else {
+        vals[col][row] = isLit ? 1 : 0;
+      }
+    }
+  }
+
+  const formatStr = grayscale ? 'grayscale' : 'binary';
+  const filename = `matrix_${side}_${formatStr}_colmajor.json`;
+
+  const blob = new Blob([JSON.stringify(vals, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 async function command(port, id, params) {

--- a/app.js
+++ b/app.js
@@ -72,8 +72,6 @@ $(function() {
   }
 });
 
-// startWakeLoop()
-
 function drawPattern(matrix, pattern, pos) {
   for (let col = 0; col < WIDTH; col++) {
     for (let row = 0; row < HEIGHT; row++) {
@@ -337,10 +335,10 @@ function prepareValsForDrawingRight() {
   return vals;
 }
 
-//Get matrix values set directly in a 39 x 9 item array
-function getRawValsMatrixRight() {
-	const width = matrix_right[0].length;
-	const height = matrix_right.length;
+//Get matrix values set directly in a 34 x 9 item array
+function getRawVals(matrix) {
+	const width = matrix[0].length;
+	const height = matrix.length;
 
   let vals = new Array(height)
   for (const i in [...Array(height).keys()]) {
@@ -349,26 +347,7 @@ function getRawValsMatrixRight() {
 
   for (let col = 0; col < width; col++) {
     for (let row = 0; row < height; row++) {
-      const cell = matrix_right[row][col];
-      vals[row][col] = (cell == null ||  cell == 1) ? 0 : 1
-    }
-  }
-  return vals;
-}
-
-//Get matrix values set directly in a 39 x 9 item array
-function getRawValsMatrixLeft() {
-	const width = matrix_left[0].length;
-	const height = matrix_left.length;
-
-  let vals = new Array(height)
-  for (const i in [...Array(height).keys()]) {
-    vals[i] = Array(width).fill(0)
-  }
-
-  for (let col = 0; col < width; col++) {
-    for (let row = 0; row < height; row++) {
-      const cell = matrix_left[row][col];
+      const cell = matrix[row][col];
       vals[row][col] = (cell == null || cell == 1) ? 0 : 1
     }
   }
@@ -376,55 +355,28 @@ function getRawValsMatrixLeft() {
 }
 
 //Set matrix values by decoding a 39-byte array
-function setMatrixLeftFromVals(vals) {
-  const width = matrix_left[0].length;
-  const height = matrix_left.length;
+function setMatrixFromVals(matrix, vals) {
+  const width = matrix[0].length;
+  const height = matrix.length;
 
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
       const i = col + row * width;
       const val = vals[Math.trunc(i/8)]
       const bit = (val >> i % 8) & 1;
-      matrix_left[row][col] = (bit + 1) % 2;
+      matrix[row][col] = (bit + 1) % 2;
     }
   }
 }
 
-//Set matrix values by decoding a 39-byte array
-function setMatrixRightFromVals(vals) {
-  const width = matrix_right[0].length;
-  const height = matrix_right.length;
+//Set matrix values from a 34 x 9 item array
+function setMatrixFromRawVals(matrix, vals) {
+  const width = matrix[0].length;
+  const height = matrix.length;
 
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      const i = col + row * width;
-      const val = vals[Math.trunc(i/8)]
-      const bit = (val >> i % 8) & 1;
-      matrix_right[row][col] = (bit + 1) % 2;
-    }
-  }
-}
-
-//Set matrix values from a 39 x 9 item array
-function setMatrixRightFromRawVals(vals) {
-  const width = matrix_right[0].length;
-  const height = matrix_right.length;
-
-  for (let row = 0; row < height; row++) {
-    for (let col = 0; col < width; col++) {
-      matrix_right[row][col] = !!!vals[row][col]
-    }
-  }
-}
-
-//Set matrix values from a 39 x 9 item array
-function setMatrixLeftFromRawVals(vals) {
-  const width = matrix_left[0].length;
-  const height = matrix_left.length;
-
-  for (let row = 0; row < height; row++) {
-    for (let col = 0; col < width; col++) {
-      matrix_left[row][col] = !!!vals[row][col]
+      matrix[row][col] = !!!vals[row][col]
     }
   }
 }
@@ -432,8 +384,8 @@ function setMatrixLeftFromRawVals(vals) {
 function exportMatrixLeft(raw) {
   let vals
   if (raw) {
-    //set vals as a 39 by 9 byte array
-    vals = getRawValsMatrixLeft()
+    //set vals as a 34 by 9 byte array
+    vals = getRawVals(matrix_left)
   } else {
     //encode vals into a 39-byte array
     vals = prepareValsForDrawingLeft();
@@ -453,8 +405,8 @@ function exportMatrixLeft(raw) {
 function exportMatrixRight(raw) {
   let vals
   if (raw) {
-    //set vals as a 39 by 9 byte array
-    vals = getRawValsMatrixRight()
+    //set vals as a 34 by 9 byte array
+    vals = getRawVals(matrix_right)
   } else {
     //encode vals into a 39-byte array
     vals = prepareValsForDrawingRight();
@@ -485,9 +437,9 @@ function importMatrixLeft() {
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
       if (vals[0].length > 1) {
-        setMatrixLeftFromRawVals(vals)
+        setMatrixFromRawVals(matrix_left, vals)
       } else {
-        setMatrixLeftFromVals(vals);
+        setMatrixFromVals(matrix_left, vals);
       }
       updateMatrix(matrix_left, 'left')
       sendToDisplay(true);
@@ -509,9 +461,9 @@ function importMatrixRight() {
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
       if (vals[0].length > 1) {
-        setMatrixRightFromRawVals(vals)
+        setMatrixFromRawVals(matrix_right, vals)
       } else {
-        setMatrixRightFromVals(vals);
+        setMatrixFromVals(matrix_right, vals);
       }
       updateMatrix(matrix_right, 'right')
       sendToDisplay(true);

--- a/app.js
+++ b/app.js
@@ -157,16 +157,10 @@ function initOptions() {
    importMatrixRight();
   });
    $('#exportLeftBtn').click(function() {
-    //Export raw data (i.e. a 2D array instead of a 1d array of encoded bits)
-   exportMatrixLeft(true);
-  // No need to suport export of encoded file since import can handle either type
-  //  exportMatrixLeft(false)
+    exportMatrixLeft();
   });
    $('#exportRightBtn').click(function() {
-   //Export raw data (i.e. a 2D array instead of a 1d array of encoded bits)
-   exportMatrixRight(true);
-  // No need to suport export of encoded file since import can handle either type
-  //  exportMatrixRight(false)
+    exportMatrixRight();
   });
 	$('#wakeBtn').click(function() {
     wake(portLeft, true);
@@ -376,21 +370,14 @@ function setMatrixFromRawVals(matrix, vals) {
 
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      matrix[row][col] = !!!vals[row][col]
+      matrix[row][col] = vals[row][col] ? 0 : 1;
     }
   }
 }
 
-function exportMatrixLeft(raw) {
-  let vals
-  if (raw) {
-    //set vals as a 34 by 9 byte array
-    vals = getRawVals(matrix_left)
-  } else {
-    //encode vals into a 39-byte array
-    vals = prepareValsForDrawingLeft();
-  }
-  //save json file
+function exportMatrixLeft() {
+  // Export as 34x9 2D array
+  const vals = getRawVals(matrix_left);
   const blob = new Blob([JSON.stringify(vals)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -402,23 +389,16 @@ function exportMatrixLeft(raw) {
   URL.revokeObjectURL(url);
 }
 
-function exportMatrixRight(raw) {
-  let vals
-  if (raw) {
-    //set vals as a 34 by 9 byte array
-    vals = getRawVals(matrix_right)
-  } else {
-    //encode vals into a 39-byte array
-    vals = prepareValsForDrawingRight();
-  }
+function exportMatrixRight() {
+  // Export as 34x9 2D array
+  const vals = getRawVals(matrix_right);
   console.log('Exported values')
   console.log(vals)
-  //save json file
   const blob = new Blob([JSON.stringify(vals)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `${raw ? 'matrix_right(raw).json' : 'matrix_right.json'}`;
+  a.download = "matrix_right.json";
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/app.js
+++ b/app.js
@@ -258,22 +258,6 @@ function prepareValsForDrawingLeft() {
   return vals;
 }
 
-function getCellVals(vals) {
-  const cellVals = []
-  for (const val of vals) {
-    const bVal = val.toString(2).split('').reverse().join('');
-    const s = bVal.padEnd(8, "0")
-    for (const c of s) {
-      if (cellVals.length < 306) {
-        cellVals.push(parseInt(c))
-      } else {
-        break;
-      }
-    }
-  }
-  return cellVals;
-}
-
 function prepareValsForDrawingRight() {
 	const width = matrix_right[0].length;
 	const height = matrix_right.length;
@@ -295,12 +279,13 @@ function prepareValsForDrawingRight() {
 function setMatrixLeftFromVals(vals) {
   const width = matrix_left[0].length;
   const height = matrix_left.length;
-  const cellVals = getCellVals(vals);
 
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      const val = cellVals.shift()
-      matrix_left[row][col] = (val + 1) % 2;
+      const i = col + row * width;
+      const val = vals[Math.trunc(i/8)]
+      const bit = (val >> i % 8) & 1;
+      matrix_left[row][col] = (bit + 1) % 2;
     }
   }
 }
@@ -308,12 +293,13 @@ function setMatrixLeftFromVals(vals) {
 function setMatrixRightFromVals(vals) {
   const width = matrix_right[0].length;
   const height = matrix_right.length;
-  const cellVals = getCellVals(vals);
 
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      const val = cellVals.shift()
-      matrix_right[row][col] = (val + 1) % 2;
+      const i = col + row * width;
+      const val = vals[Math.trunc(i/8)]
+      const bit = (val >> i % 8) & 1;
+      matrix_right[row][col] = (bit + 1) % 2;
     }
   }
 }

--- a/app.js
+++ b/app.js
@@ -145,6 +145,18 @@ function initOptions() {
     updateTableLeft();
     sendToDisplay(true);
   });
+  $('#importLeftBtn').click(function() {
+   importMatrixLeft();
+  });
+   $('#imporRighttBtn').click(function() {
+   importMatrixRight();
+  });
+   $('#exportLeftBtn').click(function() {
+   exportMatrixLeft();
+  });
+   $('#exporRighttBtn').click(function() {
+   exportMatrixRight();
+  });
 	$('#wakeBtn').click(function() {
     wake(portLeft, true);
     wake(portRight, true);
@@ -264,6 +276,93 @@ function prepareValsForDrawingRight() {
   return vals;
 }
 
+function setMatrixLeftFromVals(vals) {
+  const width = matrix_left[0].length;
+  const height = matrix_left.length;
+
+  for (let col = 0; col < width; col++) {
+    for (let row = 0; row < height; row++) {
+      matrix_left[row][col] = vals.shift();
+    }
+  }
+
+function setMatrixRightFromVals(vals) {
+  const width = matrix_right[0].length;
+  const height = matrix_right.length;
+
+  for (let col = 0; col < width; col++) {
+    for (let row = 0; row < height; row++) {
+      matrix_right[row][col] = vals.shift();
+    }
+  }
+}
+
+function exportMatrixLeft() {
+  const vals = prepareValsForDrawingLeft();
+  //save json file
+  const blob = new Blob([JSON.stringify(vals)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "matrix_left.json";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function exportMatrixRight() {
+  const vals = prepareValsForDrawingRight();
+  //save json file
+  const blob = new Blob([JSON.stringify(vals)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "matrix_right.json";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function importMatrixLeft() {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json";
+  input.onchange = async function (event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function (e) {
+      const vals = JSON.parse(e.target.result);
+      setMatrixLeftFromVals(vals);
+      updateTableLeft();
+      sendToDisplay(true);
+    };
+    reader.readAsText(file);
+  };
+  input.click();
+}
+function importMatrixRight() {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json";
+  input.onchange = async function (event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function (e) {
+      const vals = JSON.parse(e.target.result);
+      setMatrixRightFromVals(vals);
+      updateTableRight();
+      sendToDisplay(true);
+    };
+    reader.readAsText(file);
+  };
+  input.click();
+}
 
 async function sendToDisplay(recurse) {
     await sendToDisplayLeft(recurse);

--- a/app.js
+++ b/app.js
@@ -346,9 +346,9 @@ function importMatrixLeft() {
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
       setMatrixLeftFromVals(vals);
-      // updateTableLeft();
       updateMatrix(matrix_left, 'left')
       sendToDisplay(true);
+      $("#select-left").val('Custom');
     };
     reader.readAsText(file);
   };
@@ -366,9 +366,9 @@ function importMatrixRight() {
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
       setMatrixRightFromVals(vals);
-      // updateTableRight();
       updateMatrix(matrix_right, 'right')
       sendToDisplay(true);
+       $("#select-right").val('Custom');
     };
     reader.readAsText(file);
   };

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ $(function() {
   initOptions();
   startWakeLoop()
 
-  for (pattern of PATTERNS) {
+  for (const pattern of PATTERNS) {
     $("#select-left").append(`<option value="${pattern}">${pattern}</option>`);
     $("#select-left").on("change", async function() {
       if (pattern == 'Custom') return;
@@ -158,10 +158,20 @@ function initOptions() {
    importMatrixRight();
   });
    $('#exportLeftBtn').click(function() {
-   exportMatrixLeft();
+    //Export raw data (i.e. a 2D array instead of a 1d array of encoded bits)
+   exportMatrixLeft(true);
+  // No need to suport export of encoded file since import can handle either type
+  //  exportMatrixLeft(false)
   });
    $('#exportRightBtn').click(function() {
+<<<<<<< HEAD
    exportMatrixRight();
+=======
+   //Export raw data (i.e. a 2D array instead of a 1d array of encoded bits)
+   exportMatrixRight(true);
+  // No need to suport export of encoded file since import can handle either type
+  //  exportMatrixRight(false)
+>>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
   });
 	$('#wakeBtn').click(function() {
     wake(portLeft, true);
@@ -249,6 +259,7 @@ async function checkFirmwareVersion(port, side) {
   reader.releaseLock();
 }
 
+//Get matrix values encoded as a 39-byte array
 function prepareValsForDrawingLeft() {
 	const width = matrix_left[0].length;
 	const height = matrix_left.length;
@@ -267,6 +278,7 @@ function prepareValsForDrawingLeft() {
   return vals;
 }
 
+//Get matrix values encoded as a 39-byte array
 function prepareValsForDrawingRight() {
 	const width = matrix_right[0].length;
 	const height = matrix_right.length;
@@ -285,6 +297,45 @@ function prepareValsForDrawingRight() {
   return vals;
 }
 
+//Get matrix values set directly in a 39 x 9 item array
+function getRawValsMatrixRight() {
+	const width = matrix_right[0].length;
+	const height = matrix_right.length;
+
+  let vals = new Array(height)
+  for (const i in [...Array(height).keys()]) {
+    vals[i] = Array(width).fill(0)
+  }
+
+  for (let col = 0; col < width; col++) {
+    for (let row = 0; row < height; row++) {
+      const cell = matrix_right[row][col];
+      vals[row][col] = (cell == null ||  cell == 1) ? 0 : 1
+    }
+  }
+  return vals;
+}
+
+//Get matrix values set directly in a 39 x 9 item array
+function getRawValsMatrixLeft() {
+	const width = matrix_left[0].length;
+	const height = matrix_left.length;
+
+  let vals = new Array(height)
+  for (const i in [...Array(height).keys()]) {
+    vals[i] = Array(width).fill(0)
+  }
+
+  for (let col = 0; col < width; col++) {
+    for (let row = 0; row < height; row++) {
+      const cell = matrix_left[row][col];
+      vals[row][col] = (cell == null || cell == 1) ? 0 : 1
+    }
+  }
+  return vals;
+}
+
+//Set matrix values by decoding a 39-byte array
 function setMatrixLeftFromVals(vals) {
   const width = matrix_left[0].length;
   const height = matrix_left.length;
@@ -295,6 +346,7 @@ function setMatrixLeftFromVals(vals) {
       const val = vals[Math.trunc(i/8)]
       const bit = (val >> i % 8) & 1;
       matrix_left[row][col] = (bit + 1) % 2;
+<<<<<<< HEAD
     }
   }
 }
@@ -309,12 +361,60 @@ function setMatrixRightFromVals(vals) {
       const val = vals[Math.trunc(i/8)]
       const bit = (val >> i % 8) & 1;
       matrix_right[row][col] = (bit + 1) % 2;
+=======
+>>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
     }
   }
 }
 
-function exportMatrixLeft() {
-  const vals = prepareValsForDrawingLeft();
+//Set matrix values by decoding a 39-byte array
+function setMatrixRightFromVals(vals) {
+  const width = matrix_right[0].length;
+  const height = matrix_right.length;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const i = col + row * width;
+      const val = vals[Math.trunc(i/8)]
+      const bit = (val >> i % 8) & 1;
+      matrix_right[row][col] = (bit + 1) % 2;
+    }
+  }
+}
+
+//Set matrix values from a 39 x 9 item array
+function setMatrixRightFromRawVals(vals) {
+  const width = matrix_right[0].length;
+  const height = matrix_right.length;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      matrix_right[row][col] = !!!vals[row][col]
+    }
+  }
+}
+
+//Set matrix values from a 39 x 9 item array
+function setMatrixLeftFromRawVals(vals) {
+  const width = matrix_left[0].length;
+  const height = matrix_left.length;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      matrix_left[row][col] = !!!vals[row][col]
+    }
+  }
+}
+
+function exportMatrixLeft(raw) {
+  let vals
+  if (raw) {
+    //set vals as a 39 by 9 byte array
+    vals = getRawValsMatrixLeft()
+  } else {
+    //encode vals into a 39-byte array
+    vals = prepareValsForDrawingLeft();
+  }
   //save json file
   const blob = new Blob([JSON.stringify(vals)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
@@ -327,8 +427,20 @@ function exportMatrixLeft() {
   URL.revokeObjectURL(url);
 }
 
+<<<<<<< HEAD
 function exportMatrixRight() {
   const vals = prepareValsForDrawingRight();
+=======
+function exportMatrixRight(raw) {
+  let vals
+  if (raw) {
+    //set vals as a 39 by 9 byte array
+    vals = getRawValsMatrixRight()
+  } else {
+    //encode vals into a 39-byte array
+    vals = prepareValsForDrawingRight();
+  }
+>>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
   console.log('Exported values')
   console.log(vals)
   //save json file
@@ -336,7 +448,7 @@ function exportMatrixRight() {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = "matrix_right.json";
+  a.download = `${raw ? 'matrix_right(raw).json' : 'matrix_right.json'}`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
@@ -354,7 +466,15 @@ function importMatrixLeft() {
     const reader = new FileReader();
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
+<<<<<<< HEAD
       setMatrixLeftFromVals(vals);
+=======
+      if (vals[0].length > 1) {
+        setMatrixLeftFromRawVals(vals)
+      } else {
+        setMatrixLeftFromVals(vals);
+      }
+>>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
       updateMatrix(matrix_left, 'left')
       sendToDisplay(true);
       $("#select-left").val('Custom');
@@ -374,7 +494,15 @@ function importMatrixRight() {
     const reader = new FileReader();
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
+<<<<<<< HEAD
       setMatrixRightFromVals(vals);
+=======
+      if (vals[0].length > 1) {
+        setMatrixRightFromRawVals(vals)
+      } else {
+        setMatrixRightFromVals(vals);
+      }
+>>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
       updateMatrix(matrix_right, 'right')
       sendToDisplay(true);
        $("#select-right").val('Custom');
@@ -508,7 +636,10 @@ function createArray(length) {
 function startWakeLoop() {
   setInterval(() => {
     if (persist) {
+<<<<<<< HEAD
       console.log('WAKE')
+=======
+>>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
       wake(portLeft, true);
       wake(portRight, true);
     }

--- a/app.js
+++ b/app.js
@@ -148,13 +148,13 @@ function initOptions() {
   $('#importLeftBtn').click(function() {
    importMatrixLeft();
   });
-   $('#imporRighttBtn').click(function() {
+   $('#importRightBtn').click(function() {
    importMatrixRight();
   });
    $('#exportLeftBtn').click(function() {
    exportMatrixLeft();
   });
-   $('#exporRighttBtn').click(function() {
+   $('#exportRightBtn').click(function() {
    exportMatrixRight();
   });
 	$('#wakeBtn').click(function() {
@@ -258,6 +258,22 @@ function prepareValsForDrawingLeft() {
   return vals;
 }
 
+function getCellVals(vals) {
+  const cellVals = []
+  for (const val of vals) {
+    const bVal = val.toString(2).split('').reverse().join('');
+    const s = bVal.padEnd(8, "0")
+    for (const c of s) {
+      if (cellVals.length < 306) {
+        cellVals.push(parseInt(c))
+      } else {
+        break;
+      }
+    }
+  }
+  return cellVals;
+}
+
 function prepareValsForDrawingRight() {
 	const width = matrix_right[0].length;
 	const height = matrix_right.length;
@@ -279,20 +295,25 @@ function prepareValsForDrawingRight() {
 function setMatrixLeftFromVals(vals) {
   const width = matrix_left[0].length;
   const height = matrix_left.length;
+  const cellVals = getCellVals(vals);
 
-  for (let col = 0; col < width; col++) {
-    for (let row = 0; row < height; row++) {
-      matrix_left[row][col] = vals.shift();
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const val = cellVals.shift()
+      matrix_left[row][col] = (val + 1) % 2;
     }
   }
+}
 
 function setMatrixRightFromVals(vals) {
   const width = matrix_right[0].length;
   const height = matrix_right.length;
+  const cellVals = getCellVals(vals);
 
-  for (let col = 0; col < width; col++) {
-    for (let row = 0; row < height; row++) {
-      matrix_right[row][col] = vals.shift();
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const val = cellVals.shift()
+      matrix_right[row][col] = (val + 1) % 2;
     }
   }
 }
@@ -313,6 +334,8 @@ function exportMatrixLeft() {
 
 function exportMatrixRight() {
   const vals = prepareValsForDrawingRight();
+  console.log('Exported values')
+  console.log(vals)
   //save json file
   const blob = new Blob([JSON.stringify(vals)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
@@ -337,7 +360,8 @@ function importMatrixLeft() {
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
       setMatrixLeftFromVals(vals);
-      updateTableLeft();
+      // updateTableLeft();
+      updateMatrix(matrix_left, 'left')
       sendToDisplay(true);
     };
     reader.readAsText(file);
@@ -356,7 +380,8 @@ function importMatrixRight() {
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
       setMatrixRightFromVals(vals);
-      updateTableRight();
+      // updateTableRight();
+      updateMatrix(matrix_right, 'right')
       sendToDisplay(true);
     };
     reader.readAsText(file);

--- a/app.js
+++ b/app.js
@@ -164,14 +164,10 @@ function initOptions() {
   //  exportMatrixLeft(false)
   });
    $('#exportRightBtn').click(function() {
-<<<<<<< HEAD
-   exportMatrixRight();
-=======
    //Export raw data (i.e. a 2D array instead of a 1d array of encoded bits)
    exportMatrixRight(true);
   // No need to suport export of encoded file since import can handle either type
   //  exportMatrixRight(false)
->>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
   });
 	$('#wakeBtn').click(function() {
     wake(portLeft, true);
@@ -346,23 +342,6 @@ function setMatrixLeftFromVals(vals) {
       const val = vals[Math.trunc(i/8)]
       const bit = (val >> i % 8) & 1;
       matrix_left[row][col] = (bit + 1) % 2;
-<<<<<<< HEAD
-    }
-  }
-}
-
-function setMatrixRightFromVals(vals) {
-  const width = matrix_right[0].length;
-  const height = matrix_right.length;
-
-  for (let row = 0; row < height; row++) {
-    for (let col = 0; col < width; col++) {
-      const i = col + row * width;
-      const val = vals[Math.trunc(i/8)]
-      const bit = (val >> i % 8) & 1;
-      matrix_right[row][col] = (bit + 1) % 2;
-=======
->>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
     }
   }
 }
@@ -427,10 +406,6 @@ function exportMatrixLeft(raw) {
   URL.revokeObjectURL(url);
 }
 
-<<<<<<< HEAD
-function exportMatrixRight() {
-  const vals = prepareValsForDrawingRight();
-=======
 function exportMatrixRight(raw) {
   let vals
   if (raw) {
@@ -440,7 +415,6 @@ function exportMatrixRight(raw) {
     //encode vals into a 39-byte array
     vals = prepareValsForDrawingRight();
   }
->>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
   console.log('Exported values')
   console.log(vals)
   //save json file
@@ -466,15 +440,11 @@ function importMatrixLeft() {
     const reader = new FileReader();
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
-<<<<<<< HEAD
-      setMatrixLeftFromVals(vals);
-=======
       if (vals[0].length > 1) {
         setMatrixLeftFromRawVals(vals)
       } else {
         setMatrixLeftFromVals(vals);
       }
->>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
       updateMatrix(matrix_left, 'left')
       sendToDisplay(true);
       $("#select-left").val('Custom');
@@ -494,15 +464,11 @@ function importMatrixRight() {
     const reader = new FileReader();
     reader.onload = function (e) {
       const vals = JSON.parse(e.target.result);
-<<<<<<< HEAD
-      setMatrixRightFromVals(vals);
-=======
       if (vals[0].length > 1) {
         setMatrixRightFromRawVals(vals)
       } else {
         setMatrixRightFromVals(vals);
       }
->>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
       updateMatrix(matrix_right, 'right')
       sendToDisplay(true);
        $("#select-right").val('Custom');
@@ -636,10 +602,6 @@ function createArray(length) {
 function startWakeLoop() {
   setInterval(() => {
     if (persist) {
-<<<<<<< HEAD
-      console.log('WAKE')
-=======
->>>>>>> 5918936 (Support 2d or 1d arrray for import and export. Provide persist option to keep matrix awake)
       wake(portLeft, true);
       wake(portRight, true);
     }

--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ const VERSION_CMD = 0x20;
 
 const WIDTH = 9;
 const HEIGHT = 34;
+const WAKE_LOOP_INTERVAL_MSEC = 50_000
 
 const PATTERNS = [
   'Custom',
@@ -42,13 +43,16 @@ var msbendian = false;
 let portLeft = null;
 let portRight = null;
 let swap = false;
+let persist = false
 
 $(function() {
   matrix_left = createArray(34, 9);
   matrix_right = createArray(34, 9);
+
   updateTableLeft();
   updateTableRight();
   initOptions();
+  startWakeLoop()
 
   for (pattern of PATTERNS) {
     $("#select-left").append(`<option value="${pattern}">${pattern}</option>`);
@@ -66,6 +70,8 @@ $(function() {
     });
   }
 });
+
+// startWakeLoop()
 
 function drawPattern(matrix, pattern, pos) {
   for (let col = 0; col < WIDTH; col++) {
@@ -164,6 +170,9 @@ function initOptions() {
 	$('#sleepBtn').click(function() {
     wake(portLeft, false);
     wake(portRight, false);
+  });
+  $('#persistCb').click(function() {
+    persist = !persist;
   });
 	$('#bootloaderBtn').click(function() {
     bootloader(portLeft);
@@ -494,6 +503,16 @@ function createArray(length) {
     }
 
     return arr;
+}
+
+function startWakeLoop() {
+  setInterval(() => {
+    if (persist) {
+      console.log('WAKE')
+      wake(portLeft, true);
+      wake(portRight, true);
+    }
+  }, WAKE_LOOP_INTERVAL_MSEC)
 }
 
 async function wake(port, wake) {

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                 <button type="button" class="btn btn-default" id="bootloaderBtn">Bootloader</button>
               </div>
               <div class="btn-group">
-                <input type="checkbox" id="persistCb" class="btn btn-default">Persist
+                <input type="checkbox" id="persistCb" class="btn btn-default">Keep Awake
               </div>
               <p class="slider-wrapper">
                 <label for="brightnessRange">Brightness:</label>

--- a/index.html
+++ b/index.html
@@ -90,6 +90,21 @@
                   <button type="button" class="btn btn-default" id="exportLeftBtn">Export Left</button>
                   <button type="button" class="btn btn-default" id="exportRightBtn">Export Right</button>
               </div>
+              <div class="export-section">
+                <h3>Export for Software</h3>
+
+                <div class="radio-group">
+                  <label><input type="radio" name="exportFormat" value="binary"> Binary (0/1)</label>
+                  <label><input type="radio" name="exportFormat" value="grayscale" checked> Grayscale (0-255)</label>
+                </div>
+
+                <p>Layout: fixed column-major (9x34), matching the LED matrix orientation.</p>
+
+                <div class="btn-group">
+                  <button type="button" class="btn btn-default" id="exportLeftSoftwareBtn">Export Left (JSON)</button>
+                  <button type="button" class="btn btn-default" id="exportRightSoftwareBtn">Export Right (JSON)</button>
+                </div>
+              </div>
                 <!--<button type="button" class="btn btn-default" id="sendButton">Send</button>-->
               </div>
 

--- a/index.html
+++ b/index.html
@@ -70,7 +70,9 @@
                 <button type="button" class="btn btn-default" id="sleepBtn">Sleep</button>
                 <button type="button" class="btn btn-default" id="bootloaderBtn">Bootloader</button>
               </div>
-
+              <div class="btn-group">
+                <input type="checkbox" id="persistCb" class="btn btn-default">Persist
+              </div>
               <p class="slider-wrapper">
                 <label for="brightnessRange">Brightness:</label>
                 <input type="range" id="brightnessRange" min="0" max="255">

--- a/index.html
+++ b/index.html
@@ -80,8 +80,17 @@
                 <button type="button" class="btn btn-default" id="clearLeftBtn">Clear Left</button>
                 <button type="button" class="btn btn-default" id="clearRightBtn">Clear Right</button>
               </div>
-              <!--<button type="button" class="btn btn-default" id="sendButton">Send</button>-->
-            </div>
+              <div class="btn-group">
+                <button type="button" class="btn btn-default" id="importLeftBtn">Import Left</button>
+                <button type="button" class="btn btn-default" id="importRightBtn">Import Right</button>
+              </div>
+              <div class="btn-group">
+                  <button type="button" class="btn btn-default" id="exportLeftBtn">Export Left</button>
+                  <button type="button" class="btn btn-default" id="exportRightBtn">Export Right</button>
+              </div>
+              <div>
+                <!--<button type="button" class="btn btn-default" id="sendButton">Send</button>-->
+              </div>
 
             <div>
               <h2>Learn More</h2>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,6 @@
                   <button type="button" class="btn btn-default" id="exportLeftBtn">Export Left</button>
                   <button type="button" class="btn btn-default" id="exportRightBtn">Export Right</button>
               </div>
-              <div>
                 <!--<button type="button" class="btn btn-default" id="sendButton">Send</button>-->
               </div>
 


### PR DESCRIPTION
This PR is stacked directly on top of PR #11 (Import and Export patterns by @MidnightJava) and adds a software-oriented JSON export feature. All of the behavior from PR #11 remains unchanged.

## Relationship to PR #11

- This branch is based on the current head of PR #11.
- All of Mark’s changes (import/export, persist checkbox, wake loop, etc.) are included as-is.
- This PR only adds a separate JSON export path for software workflows.

That means maintainers can:
- Merge PR #11 alone, or
- Merge this PR instead, which includes PR #11 plus the software JSON export additions.

## Additions in this PR

### 1. UI: “Export for Software” section

Below the existing Import/Export buttons, this PR adds:

- **Format options**
  - `Binary (0/1)`
  - `Grayscale (0–255)` (default)

- **Layout**
  - Fixed **column-major** layout (`9 x 34`), matching the physical LED matrix orientation and my icon library usage.

- **Buttons**
  - `Export Left (JSON)`
  - `Export Right (JSON)`

The existing Import/Export buttons and the 39‑byte hardware pattern format from PR #11 remain exactly as implemented there.

### 2. JSON export format

The new buttons generate a `.json` file with:

- **Shape**
  - `9 x 34` (outer array = columns, inner array = rows)

- **Values**
  - Binary mode: `0` (off) or `1` (on)
  - Grayscale mode: `0` (off) or `255` (fully lit)

This is derived from the existing convention where `matrix[row][col] === 0` means “LED on”.

Filenames follow this pattern, e.g.:

- `matrix_left_grayscale_colmajor.json`
- `matrix_right_binary_colmajor.json`

### 3. Implementation details

- `index.html`
  - Adds the “Export for Software” section with:
    - A format radio group (binary vs grayscale).
    - Fixed-layout note (“fixed column-major (9x34)”).
    - `Export Left/Right (JSON)` buttons.

- `app.js`
  - Calls `initSoftwareExportOptions()` in the main `$(function() { ... })`.
  - Adds `initSoftwareExportOptions()`:
    - Wires `#exportLeftSoftwareBtn` / `#exportRightSoftwareBtn` to the new behavior.
    - Reads the `exportFormat` radio value.
  - Adds `exportMatrixSoftware(matrix, side, grayscale)`:
    - Builds a fixed column‑major `9 x 34` array from the existing `matrix_*`.
    - Maps internal `0/1` cells to `0/1` or `0/255`.
    - Triggers a JSON download with a descriptive filename.

## Compatibility

- No changes to the 39‑byte hardware import/export from PR #11.
- JSON export is fully additive and only affects the new “Export for Software” UI.
- Intended for use cases like the LED matrix monitoring project (icon libraries, grayscale icons, etc.).

Happy to adjust naming/text if you prefer different terminology for the new options.